### PR TITLE
Null check fix _fetchCustom

### DIFF
--- a/lib/303/reqrest_resource/model/resoruce_model.dart
+++ b/lib/303/reqrest_resource/model/resoruce_model.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'resoruce_model.g.dart';
 
-String _fetchCustom(String data) {
+String _fetchCustom(String? data) {
   return 'aa';
 }
 


### PR DESCRIPTION
Null check kontrolü yapılmadığı takdirde servis isteği fırlatılan hatadan dolayı loading state'i false set edilmiş durumda takılı kalıyor.